### PR TITLE
Fix high-severity Dependabot alerts for pillow and urllib3

### DIFF
--- a/modules/inrobot/cdf_inrobot_common/functions/fn_contextualize_robot_data/requirements.txt
+++ b/modules/inrobot/cdf_inrobot_common/functions/fn_contextualize_robot_data/requirements.txt
@@ -19,4 +19,4 @@ requests==2.32.0
 requests-oauthlib==1.3.1
 retry==0.9.2
 six==1.15.0
-urllib3==1.26.19
+urllib3==2.6.3

--- a/modules/inrobot/cdf_inrobot_common/functions/fn_gauge_reading/requirements.txt
+++ b/modules/inrobot/cdf_inrobot_common/functions/fn_gauge_reading/requirements.txt
@@ -19,4 +19,4 @@ requests==2.32.0
 requests-oauthlib==1.3.1
 retry==0.9.2
 six==1.15.0
-urllib3==1.26.19
+urllib3==2.6.3

--- a/modules/inrobot/cdf_inrobot_common/functions/fn_get_ir_data_from_ir_raw/requirements.txt
+++ b/modules/inrobot/cdf_inrobot_common/functions/fn_get_ir_data_from_ir_raw/requirements.txt
@@ -20,4 +20,4 @@ requests==2.32.0
 requests-oauthlib==1.3.1
 retry==0.9.2
 six==1.15.0
-urllib3==1.26.19
+urllib3==2.6.3

--- a/modules/inrobot/cdf_inrobot_common/functions/fn_threesixty/requirements.txt
+++ b/modules/inrobot/cdf_inrobot_common/functions/fn_threesixty/requirements.txt
@@ -1,6 +1,6 @@
 bosdyn-client==3.3.2
 cognite-sdk==5.*
-Pillow==10.3.0
+Pillow==12.1.1
 py360convert==0.1.0
 scipy==1.10.0
 six==1.16.0


### PR DESCRIPTION
## Summary
- Upgrade **pillow** `10.3.0` → `12.1.1` in `fn_threesixty` to fix out-of-bounds write when loading PSD images (alert #23)
- Upgrade **urllib3** `1.26.19` → `2.6.3` in `fn_get_ir_data_from_ir_raw`, `fn_contextualize_robot_data`, and `fn_gauge_reading` to fix decompression-bomb bypass, improper handling of highly compressed data, and unbounded decompression chain vulnerabilities (alerts #14–22)

Resolves all 10 open high-severity Dependabot alerts.

## Test plan
- [ ] Verify `fn_threesixty` function still works correctly with pillow 12.1.1
- [ ] Verify `fn_get_ir_data_from_ir_raw`, `fn_contextualize_robot_data`, and `fn_gauge_reading` functions work correctly with urllib3 2.6.3 (major version bump from 1.x)
- [ ] Confirm Dependabot alerts are resolved after merge